### PR TITLE
handle KeyError in marked_text property

### DIFF
--- a/dotagent/compiler/_program.py
+++ b/dotagent/compiler/_program.py
@@ -594,7 +594,10 @@ class Program:
     @property
     def marked_text(self):
         if self._executor is not None:
-            return self._variables["@raw_prefix"]
+            try:
+                return self._variables["@raw_prefix"]
+            except KeyError:
+                return self._text
         else:
             return self._text
     


### PR DESCRIPTION
In case there is a key error when returning program.marked_text, simply return self._text